### PR TITLE
feat(Task2): Integrate QPixmap for display and caching

### DIFF
--- a/Project_QT/src/CreatureSpriteManager.cpp
+++ b/Project_QT/src/CreatureSpriteManager.cpp
@@ -1,20 +1,12 @@
 #include "CreatureSpriteManager.h"
-#include "GameSprite.h" // For Outfit and potentially GameSprite fetching
-// #include "GraphicManager.h" // If needed to fetch base sprites (dependency to be managed)
+// GameSprite.h is already included in CreatureSpriteManager.h for Outfit
+// #include "GraphicManager.h" // Dependency to be managed if actual GameSprites are fetched
 #include <QImage>
-#include <QPainter> // For scaling and manipulation if not directly on QImage
+#include <QPixmap> // Added for QPixmap
+#include <QPainter> 
 #include <QDebug>
 
-// Global instance, similar to g_creature_sprites in wxwidgets
-// Consider if a global instance is the best approach in Qt (singleton or dependency injection might be alternatives)
-// For a direct port, a global static instance can be declared.
-// CreatureSpriteManager g_qt_creature_sprites; // Definition would go here if it's global static.
-
-
 CreatureSpriteManager::CreatureSpriteManager() {
-    // Constructor
-    // If depending on GraphicManager, it might be passed here or set via a method.
-    // m_graphic_manager = nullptr; // Initialize if it's a member
 }
 
 CreatureSpriteManager::~CreatureSpriteManager() {
@@ -22,7 +14,7 @@ CreatureSpriteManager::~CreatureSpriteManager() {
 }
 
 void CreatureSpriteManager::clear() {
-    m_sprite_image_cache.clear();
+    m_sprite_pixmap_cache.clear();
 }
 
 QString CreatureSpriteManager::generateCacheKey(int looktype, const Outfit* outfit_ptr, int width, int height) const {
@@ -30,7 +22,7 @@ QString CreatureSpriteManager::generateCacheKey(int looktype, const Outfit* outf
                       .arg(looktype)
                       .arg(width)
                       .arg(height);
-    if (outfit_ptr) { // Check if outfit_ptr is not null
+    if (outfit_ptr) { 
         key += QString("_head:%1_body:%2_legs:%3_feet:%4")
                    .arg(outfit_ptr->lookHead)
                    .arg(outfit_ptr->lookBody)
@@ -40,108 +32,84 @@ QString CreatureSpriteManager::generateCacheKey(int looktype, const Outfit* outf
     return key;
 }
 
-
-QImage CreatureSpriteManager::getSpriteImage(int looktype, int width, int height) {
-    // For the base version without specific outfit colors, we can pass a default Outfit struct
-    // or handle the null outfit_ptr case in generateCacheKey and createSpriteImage.
-    Outfit default_outfit; // An outfit with all colors as 0, or just lookType set
+QPixmap CreatureSpriteManager::getSpritePixmap(int looktype, int width, int height) {
+    Outfit default_outfit; 
     default_outfit.lookType = looktype;
-    return getSpriteImage(looktype, default_outfit, width, height);
+    return getSpritePixmap(looktype, default_outfit, width, height);
 }
 
-QImage CreatureSpriteManager::getSpriteImage(int looktype, const Outfit& outfit, int width, int height) {
+QPixmap CreatureSpriteManager::getSpritePixmap(int looktype, const Outfit& outfit, int width, int height) {
     QString key = generateCacheKey(looktype, &outfit, width, height);
     
-    if (m_sprite_image_cache.contains(key)) {
-        return m_sprite_image_cache.value(key);
+    if (m_sprite_pixmap_cache.contains(key)) {
+        return m_sprite_pixmap_cache.value(key);
     }
     
-    QImage image = createSpriteImage(looktype, outfit, width, height);
-    if (!image.isNull()) {
-        m_sprite_image_cache.insert(key, image);
+    QPixmap pixmap = createSpritePixmap(looktype, outfit, width, height);
+    if (!pixmap.isNull()) {
+        m_sprite_pixmap_cache.insert(key, pixmap);
     } else {
-        qWarning() << "CreatureSpriteManager: createSpriteImage returned null for key" << key;
-        // Return a default/placeholder image or an empty QImage
-        return QImage(width, height, QImage::Format_ARGB32_Premultiplied); // Example: transparent placeholder
+        qWarning() << "CreatureSpriteManager: createSpritePixmap returned null for key" << key;
+        return QPixmap(width, height); 
     }
-    return image;
+    return pixmap;
 }
 
-void CreatureSpriteManager::generateCreatureSpriteImages(const BrushVector& creatures, int width, int height) {
-    for (CreatureBrush* cb : creatures) { // Assuming BrushVector is now QVector<CreatureBrush*>
+void CreatureSpriteManager::generateCreatureSpritePixmaps(const BrushVector& creatures, int width, int height) {
+    for (CreatureBrush* cb : creatures) { 
         if (cb) { 
             const Outfit& creature_outfit = cb->getOutfit();
             int lt = creature_outfit.lookType; 
             if (lt > 0) {
-                // If outfit has specific colors (non-zero head, body, etc.), generate with them
                 if (creature_outfit.lookHead || creature_outfit.lookBody || creature_outfit.lookLegs || creature_outfit.lookFeet) {
-                    getSpriteImage(lt, creature_outfit, width, height);
+                    getSpritePixmap(lt, creature_outfit, width, height);
                 } else {
-                    // Otherwise, generate the base looktype image
-                    getSpriteImage(lt, width, height); // This will use the default outfit
+                    getSpritePixmap(lt, width, height); 
                 }
             }
         }
     }
 }
 
-QImage CreatureSpriteManager::createSpriteImage(int looktype, int width, int height) {
+QPixmap CreatureSpriteManager::createSpritePixmap(int looktype, int width, int height) {
     Outfit default_outfit;
     default_outfit.lookType = looktype;
-    // Default colors (0) will mean base sprite in colorizeSpritePart
-    return createSpriteImage(looktype, default_outfit, width, height);
+    return createSpritePixmap(looktype, default_outfit, width, height);
 }
 
-QImage CreatureSpriteManager::createSpriteImage(int looktype, const Outfit& outfit, int target_width, int target_height) {
-    // 1. Get the base GameSprite for the looktype.
-    //    This is a critical dependency. For now, we'll simulate getting a GameSprite.
-    //    In a real scenario, this would come from GraphicManager or a similar source.
-    
-    // --- Placeholder for GameSprite acquisition ---
-    // This part needs to be replaced with actual logic to get a GameSprite,
-    // possibly involving GraphicManager. For now, create a dummy one.
+QPixmap CreatureSpriteManager::createSpritePixmap(int looktype, const Outfit& outfit, int target_width, int target_height) {
     QSharedPointer<GameSprite> base_game_sprite = QSharedPointer<GameSprite>(new GameSprite());
-    // Setup a default image for the dummy GameSprite if it's not already initialized
     if (base_game_sprite->getImage().isNull() || base_game_sprite->getImage().size().isEmpty()) {
         QImage dummy_base(32,32, QImage::Format_ARGB32_Premultiplied);
-        dummy_base.fill(Qt::cyan); // Fill with a distinct color for easy identification if it's used
-        // Add some template marker colors for colorizeSpritePart to work on
-        // Yellow for head (top-left)
+        dummy_base.fill(Qt::cyan); 
         for(int y=0; y < 8; ++y) for(int x=0; x < 8; ++x) dummy_base.setPixelColor(x,y, QColor(255,255,0));
-        // Red for body (top-right)
         for(int y=0; y < 8; ++y) for(int x=8; x < 16; ++x) dummy_base.setPixelColor(x,y, QColor(255,0,0));
-        // Green for legs (bottom-left)
         for(int y=8; y < 16; ++y) for(int x=0; x < 8; ++x) dummy_base.setPixelColor(x,y, QColor(0,255,0));
-        // Blue for feet (bottom-right)
         for(int y=8; y < 16; ++y) for(int x=8; x < 16; ++x) dummy_base.setPixelColor(x,y, QColor(0,0,255));
         base_game_sprite->setImage(dummy_base);
-        base_game_sprite->sprite_parts.append(dummy_base); // Ensure it has at least one part
-        base_game_sprite->width = 1; base_game_sprite->height = 1; // Assuming 1x1 pattern for base part
+        base_game_sprite->sprite_parts.append(dummy_base); 
+        base_game_sprite->width = 1; base_game_sprite->height = 1; 
         base_game_sprite->layers = 1; base_game_sprite->frames = 1;
         base_game_sprite->pattern_x =1; base_game_sprite->pattern_y =1; base_game_sprite->pattern_z = 1;
     }
-    // --- End Placeholder ---
-
 
     if (!base_game_sprite || base_game_sprite->getImage().isNull()) { 
         qWarning() << "CreatureSpriteManager: Could not get/create base GameSprite for looktype" << looktype;
-        return QImage(); 
+        return QPixmap(); 
     }
 
     QImage source_image_part = base_game_sprite->getSpritePart(0,0,0,0,0,0,0); 
     if(source_image_part.isNull()) source_image_part = base_game_sprite->getImage(); 
 
-
     QImage colorized_image = base_game_sprite->colorizeSpritePart(source_image_part, outfit);
 
     if (colorized_image.isNull()) {
         qWarning() << "CreatureSpriteManager: Colorization resulted in null image for looktype" << looktype;
-        return QImage();
+        return QPixmap();
     }
     
     QImage final_image = colorized_image.scaled(target_width, target_height, Qt::KeepAspectRatio, Qt::SmoothTransformation);
     
-    // Ensure the image has the exact target dimensions, padding with transparency if needed (like original)
     if (final_image.width() != target_width || final_image.height() != target_height) {
         QImage exact_size_image(target_width, target_height, QImage::Format_ARGB32_Premultiplied);
         exact_size_image.fill(Qt::transparent);
@@ -153,17 +121,5 @@ QImage CreatureSpriteManager::createSpriteImage(int looktype, const Outfit& outf
         final_image = exact_size_image;
     }
 
-    // Original wxImage version set a mask color (e.g., magenta) for transparency.
-    // QImage handles transparency with its alpha channel. If the source images and
-    // colorization process correctly maintain alpha, this should be fine.
-    // If a specific color needs to become transparent (like magenta in wxwidgets):
-    // final_image.convertTo(QImage::Format_ARGB32); // Ensure alpha channel
-    // for (int y = 0; y < final_image.height(); ++y) {
-    //     for (int x = 0; x < final_image.width(); ++x) {
-    //         if (final_image.pixel(x, y) == qRgb(255, 0, 255)) { // Magenta
-    //             final_image.setPixel(x, y, Qt::transparent);
-    //         }
-    //     }
-    // }
-    return final_image;
+    return QPixmap::fromImage(final_image);
 }

--- a/Project_QT/src/CreatureSpriteManager.h
+++ b/Project_QT/src/CreatureSpriteManager.h
@@ -3,57 +3,45 @@
 
 #include <QMap>
 #include <QString>
-#include <QSharedPointer> // For managing GameSprite objects
-#include <QVector> // For BrushVector
-#include <QImage>  // For QImage
+#include <QSharedPointer> 
+#include <QVector> 
+#include <QImage>  
+#include <QPixmap> 
 
-// Forward declarations
-class GameSprite;
-// struct Outfit; // Already in GameSprite.h, assuming it's included where needed.
-#include "GameSprite.h" // Include for Outfit struct, if not forward declared and used by value/ref
+#include "GameSprite.h" 
 
-// If BrushVector and CreatureBrush are complex, they need their own headers.
-// For now, providing simple placeholders.
-class Brush {}; // Base Brush placeholder
-class CreatureBrush : public Brush { // CreatureBrush placeholder
+class Brush {}; 
+class CreatureBrush : public Brush { 
 public:
-    // Example members based on wxwidgets/creature_brush.h
-    int lookType = 0; // Should be part of Outfit in a cleaner design
-    Outfit m_outfit; // Store the actual outfit object
+    int lookType = 0; 
+    Outfit m_outfit; 
     
     CreatureBrush(int type, const Outfit& outfit_details) : lookType(type), m_outfit(outfit_details) {}
 
-    bool isCreature() const { return true; } // Example method
+    bool isCreature() const { return true; } 
     const Outfit& getOutfit() const { return m_outfit; } 
     int getLookType() const { return m_outfit.lookType; }
 };
-using BrushVector = QVector<CreatureBrush*>; // Using QVector of CreatureBrush pointers
-
+using BrushVector = QVector<CreatureBrush*>; 
 
 class CreatureSpriteManager {
 public:
     CreatureSpriteManager();
     ~CreatureSpriteManager();
 
-    QImage getSpriteImage(int looktype, int width = 32, int height = 32);
-    QImage getSpriteImage(int looktype, const Outfit& outfit, int width = 32, int height = 32);
+    QPixmap getSpritePixmap(int looktype, int width = 32, int height = 32);
+    QPixmap getSpritePixmap(int looktype, const Outfit& outfit, int width = 32, int height = 32);
     
-    void generateCreatureSpriteImages(const BrushVector& creatures, int width = 32, int height = 32);
+    void generateCreatureSpritePixmaps(const BrushVector& creatures, int width = 32, int height = 32); 
     void clear();
 
 private:
-    QMap<QString, QImage> m_sprite_image_cache; 
+    QMap<QString, QPixmap> m_sprite_pixmap_cache; 
     
-    QImage createSpriteImage(int looktype, int width, int height); // Base without specific outfit
-    QImage createSpriteImage(int looktype, const Outfit& outfit, int width, int height); // With outfit
-
-    // Dependency: Needs access to GameSprite definitions and potentially GraphicManager
-    // to get base GameSprite objects. 
-    // For now, assume it can create/get them or it's passed in.
-    // GraphicManager* m_graphic_manager; // Example: if it needs to fetch base sprites
+    QPixmap createSpritePixmap(int looktype, int width, int height); 
+    QPixmap createSpritePixmap(int looktype, const Outfit& outfit, int width, int height); 
 
     QString generateCacheKey(int looktype, const Outfit* outfit_ptr, int width, int height) const;
 };
-
 
 #endif // CREATURESPRITEMANAGER_H

--- a/Project_QT/src/GraphicManager.cpp
+++ b/Project_QT/src/GraphicManager.cpp
@@ -4,21 +4,16 @@
 #include "EditorSprite.h"
 #include <QFile>
 #include <QBuffer>
-#include <QDebug> // For warnings/errors
-#include <QStringList> // For QStringList
+#include <QDebug> 
+#include <QStringList> 
+#include <QPixmap> // Added for QPixmap
 
-// Constants for editor sprite IDs (example, actual values might differ)
-// These would correspond to enums like EDITOR_SPRITE_SELECTION_MARKER from wxwidgets
 enum EditorSpriteId {
     EDITOR_SPRITE_SELECTION_MARKER = -1,
     EDITOR_SPRITE_BRUSH_CD_1x1 = -2,
-    // ... other editor sprite IDs
 };
 
-
 GraphicManager::GraphicManager() {
-    // Initialize client version with some default if necessary
-    // m_client_version = ...;
 }
 
 GraphicManager::~GraphicManager() {
@@ -29,18 +24,11 @@ void GraphicManager::clear() {
     m_sprite_cache.clear();
     m_item_sprite_cache.clear();
     m_creature_sprite_cache.clear();
-    // m_editor_sprite_cache.clear(); // If separate cache for editor sprites
-
     m_item_count = 0;
     m_creature_count = 0;
-    // Reset other relevant members
 }
 
 void GraphicManager::cleanSoftwareSprites() {
-    // In Qt, QImage uses implicit sharing and QSharedPointer handles memory.
-    // This function might be less relevant or could be used to clear caches
-    // more aggressively if memory profiling shows issues.
-    // For now, it can be a no-op or call clear().
     qDebug() << "GraphicManager::cleanSoftwareSprites() called - currently a no-op or consider cache clearing.";
 }
 
@@ -48,90 +36,66 @@ QSharedPointer<Sprite> GraphicManager::getSprite(int id) {
     if (m_sprite_cache.contains(id)) {
         return m_sprite_cache.value(id);
     }
-    // Potentially load on demand or return null if not found
     return QSharedPointer<Sprite>(); 
 }
 
 QSharedPointer<GameSprite> GraphicManager::getGameSprite(int id) {
-    // Game sprites might be for items or creatures, original wx had separate counts
-    // This is a simplified lookup, assumes ID is unique across items/creatures or
-    // that the calling context knows which type of ID it is.
-    // A more robust system might use prefixes or separate maps.
-    if (id >= 0 && id < m_item_count) { // Assuming item IDs are 0 to m_item_count-1
+    if (id >= 0 && id < m_item_count) { 
          if (m_item_sprite_cache.contains(id)) {
             return m_item_sprite_cache.value(id);
         }
-    } else { // Assuming creature IDs follow item IDs
-        int creature_id_offset = id - m_item_count; // Adjust ID if creatures are in a separate range
+    } else { 
+        int creature_id_offset = id - m_item_count; 
          if (m_creature_sprite_cache.contains(creature_id_offset)) {
             return m_creature_sprite_cache.value(creature_id_offset);
         }
     }
-    // TODO: Load on demand if not found, based on 'id' mapping to file/resource
     return QSharedPointer<GameSprite>();
 }
 
 QSharedPointer<EditorSprite> GraphicManager::getEditorSprite(int editor_sprite_id) {
-    // Editor sprites are often identified by negative numbers or specific enums
     if (m_sprite_cache.contains(editor_sprite_id)) {
-        // Attempt to cast Sprite to EditorSprite. This is safe if only EditorSprites are stored with these IDs.
         QSharedPointer<Sprite> sprite = m_sprite_cache.value(editor_sprite_id);
-        QSharedPointer<EditorSprite> editorSprite = qSharedPointerCast<EditorSprite>(sprite);
-        if (editorSprite) {
-            return editorSprite;
-        }
+        return qSharedPointerCast<EditorSprite>(sprite);
     }
-    // TODO: Load on demand if not found
     return QSharedPointer<EditorSprite>();
 }
 
+QPixmap GraphicManager::getSpritePixmap(int id) {
+    QSharedPointer<Sprite> sprite = getSprite(id);
+    if (sprite) {
+        return sprite->getPixmap();
+    }
+    return QPixmap(); 
+}
+
+QPixmap GraphicManager::getGameSpritePixmap(int id) {
+    QSharedPointer<GameSprite> gameSprite = getGameSprite(id);
+    if (gameSprite) {
+        return gameSprite->getPixmap();
+    }
+    return QPixmap();
+}
+
+QPixmap GraphicManager::getEditorSpritePixmap(int editor_sprite_id) {
+    QSharedPointer<EditorSprite> editorSprite = getEditorSprite(editor_sprite_id);
+    if (editorSprite) {
+        return editorSprite->getPixmap();
+    }
+    return QPixmap();
+}
 
 bool GraphicManager::loadEditorSprites() {
-    // This function would load predefined editor sprites (icons, markers, etc.)
-    // In wxwidgets, these were often from XPM files or embedded PNG data.
-    // Example:
-    // QMap<EditorSpriteSize, QString> paths_selection_marker;
-    // paths_selection_marker.insert(EDITOR_SPRITE_SIZE_16x16, ":/icons/selection_marker_16.png");
-    // paths_selection_marker.insert(EDITOR_SPRITE_SIZE_32x32, ":/icons/selection_marker_32.png");
-    // QSharedPointer<EditorSprite> sel_marker = QSharedPointer<EditorSprite>(new EditorSprite(paths_selection_marker));
-    // m_sprite_cache.insert(EDITOR_SPRITE_SELECTION_MARKER, sel_marker);
-
-    // For each editor sprite:
-    // 1. Determine its ID (e.g., EDITOR_SPRITE_SELECTION_MARKER)
-    // 2. Find its image data (e.g., from Qt resource file :/)
-    // 3. Create an EditorSprite object
-    // 4. Store it in m_sprite_cache or a dedicated editor sprite cache
-
     qDebug() << "GraphicManager::loadEditorSprites() - Placeholder. Implement loading from resources.";
-    // Example of loading a single editor sprite (assuming it's a simple image, not multiple sizes for now)
-    // QSharedPointer<EditorSprite> eraser_sprite = QSharedPointer<EditorSprite>(new EditorSprite(":/icons/eraser.png"));
-    // if (!eraser_sprite->getImage().isNull()) {
-    //    m_sprite_cache.insert(SOME_ERASER_ID_ENUM, eraser_sprite);
-    // } else {
-    //    qWarning() << "Failed to load eraser.png for editor sprite.";
-    //    return false;
-    // }
-    return true; // Placeholder
+    return true; 
 }
 
 bool GraphicManager::loadSpriteAssets(const QString& dataPath, QString& error, QStringList& warnings) {
-    // This is a high-level function that would orchestrate the loading of all game assets.
-    // 1. Call loadOTFI (or its equivalent for finding .dat and .spr paths)
-    // 2. Call loadSpriteMetadata (to parse .dat file)
-    // 3. Call loadSpriteData (to parse .spr file and link image data to GameSprites)
-
-    // For now, this is a stub.
-    // The original wxGraphicManager had complex logic for parsing these custom binary formats.
-    // That logic needs to be ported carefully.
-
-    // Example steps:
-    // if (!loadOTFI(dataPath + "/some_config_or_dir", error, warnings)) return false;
-    // if (!loadSpriteMetadata(m_metadata_file_path, error, warnings)) return false;
-    // if (!loadSpriteData(m_sprites_file_path, error, warnings)) return false;
-    
     qDebug() << "GraphicManager::loadSpriteAssets() - Placeholder for complex asset loading pipeline.";
     error = "Asset loading not yet implemented.";
-    return false; // Placeholder
+    (void)dataPath; 
+    (void)warnings; 
+    return false; 
 }
 
 QImage GraphicManager::loadImageFromData(const QByteArray& data, const char* format) {
@@ -140,7 +104,7 @@ QImage GraphicManager::loadImageFromData(const QByteArray& data, const char* for
         return image;
     }
     qWarning() << "GraphicManager::loadImageFromData - Failed to load image from data. Format:" << (format ? format : "autodetect");
-    return QImage(); // Return a null image on failure
+    return QImage(); 
 }
 
 bool GraphicManager::loadGameSpriteData(QSharedPointer<GameSprite> gameSprite, const QByteArray& sprite_data) {
@@ -148,49 +112,16 @@ bool GraphicManager::loadGameSpriteData(QSharedPointer<GameSprite> gameSprite, c
         qWarning() << "GraphicManager::loadGameSpriteData - Null GameSprite provided.";
         return false;
     }
-
-    // This function's role depends on how sprite data is stored and structured.
-    // If sprite_data is a spritesheet:
-    //   - gameSprite->loadFromSpriteSheet(QImage::fromData(sprite_data), ...);
-    // If sprite_data points to individual files (less likely for one QByteArray):
-    //   - This would need a different structure, perhaps a list of file paths.
-    
-    // The original wxGraphicManager::loadSpriteData and GameSprite::NormalImage::getRGBData
-    // handled reading from a .spr file which contained many small, potentially compressed, sprite pieces.
-    // The 'sprite_id' from the .dat file would map to an offset in the .spr file.
-    // That data was then decompressed and turned into pixel data for wxImage.
-
-    // For a Qt port, this means:
-    // 1. Reading the correct chunk from the .spr file (based on sprite_id).
-    // 2. Decompressing it (if the format uses RLE or similar, as hinted by transparent/colored runs).
-    // 3. Constructing a QImage from this raw pixel data.
-    // 4. This QImage then becomes one of the 'sprite_parts' in the GameSprite.
-
-    // This is a highly simplified placeholder. The actual implementation will be complex.
     QImage whole_sheet;
     if (whole_sheet.loadFromData(sprite_data)) {
-        // Assuming gameSprite has its dimensions (part_width, part_height, sheet_width, sheet_height) set
-        // from metadata (.dat file) previously.
-        // return gameSprite->loadFromSpriteSheet(whole_sheet, 
-        //                                       gameSprite->width * SPRITE_PART_WIDTH, // sheet total width
-        //                                       gameSprite->height * SPRITE_PART_HEIGHT, // sheet total height
-        //                                       SPRITE_PART_WIDTH, 
-        //                                       SPRITE_PART_HEIGHT);
-        qDebug() << "GraphicManager::loadGameSpriteData() - Placeholder. Needs spritesheet definition.";
-        // For now, just set the whole data as the base image for the GameSprite.
-        if(gameSprite) { // Check if gameSprite is not null
+        if(gameSprite) { 
              gameSprite->setImage(whole_sheet);
         }
         return true;
     }
-    
     qWarning() << "GraphicManager::loadGameSpriteData - Failed to load image from provided data.";
     return false;
 }
-
-
-// QString GraphicManager::getMetadataFileName() const { return m_metadata_file_path; }
-// QString GraphicManager::getSpritesFileName() const { return m_sprites_file_path; }
 
 void GraphicManager::setClientVersion(const ClientVersion& version) {
     m_client_version = version;

--- a/Project_QT/src/GraphicManager.h
+++ b/Project_QT/src/GraphicManager.h
@@ -2,102 +2,62 @@
 #define GRAPHICMANAGER_H
 
 #include <QImage>
+#include <QPixmap> // Added for QPixmap
 #include <QString>
 #include <QMap>
 #include <QVector>
-#include <QSharedPointer> // For managing sprites
-#include <QStringList> // For QStringList
+#include <QSharedPointer> 
+#include <QStringList> 
 
-// Forward declarations
 class Sprite;
 class GameSprite;
 class EditorSprite;
-class QFile; // For file operations if needed directly
+class QFile; 
 
-// If ClientVersion, Outfit, etc., are complex classes, they would need their own headers.
-// For now, assume basic or forward-declared.
-struct ClientVersion { // Placeholder
-    // Define members based on wxwidgets/client_version.h if complex logic is needed
-    // For GraphicManager, it might influence how .dat/.spr files are parsed
+struct ClientVersion { 
     QString versionString;
-    // enum DatFormat { DAT_FORMAT_UNKNOWN, DAT_FORMAT_74, ... };
-    // DatFormat getDatFormatForSignature(uint32_t signature);
 };
 
-struct SpriteLight { // Placeholder
+struct SpriteLight { 
     uint8_t intensity = 0;
-    uint8_t color = 0; // Assuming color can be represented by a simple type for now
+    uint8_t color = 0; 
 };
-
 
 class GraphicManager {
 public:
     GraphicManager();
     ~GraphicManager();
 
-    void clear(); // Clears loaded graphics
-    void cleanSoftwareSprites(); // May not be directly applicable if QImage handles its own memory well
+    void clear(); 
+    void cleanSoftwareSprites(); 
 
-    QSharedPointer<Sprite> getSprite(int id); // Generic sprite getter
-    virtual QSharedPointer<GameSprite> getGameSprite(int id); // Made virtual for Mocking
-    QSharedPointer<EditorSprite> getEditorSprite(int editor_sprite_id); // For editor-specific UI icons
+    QSharedPointer<Sprite> getSprite(int id); 
+    virtual QSharedPointer<GameSprite> getGameSprite(int id); 
+    QSharedPointer<EditorSprite> getEditorSprite(int editor_sprite_id); 
 
-    // Corresponds to GraphicManager::loadEditorSprites
+    QPixmap getSpritePixmap(int id);
+    QPixmap getGameSpritePixmap(int id);
+    QPixmap getEditorSpritePixmap(int editor_sprite_id);
+
     bool loadEditorSprites(); 
-
-    // Corresponds to GraphicManager::loadOTFI, loadSpriteMetadata, loadSpriteData
-    // These will be complex and involve parsing custom binary formats.
-    // Stubs for now.
     bool loadSpriteAssets(const QString& dataPath, QString& error, QStringList& warnings);
-    // bool loadOTFI(const QString& directoryPath, QString& error, QStringList& warnings);
-    // bool loadSpriteMetadata(const QString& datPath, QString& error, QStringList& warnings);
-    // bool loadSpriteData(const QString& sprPath, QString& error, QStringList& warnings);
-
-    // Helper for loading an image from raw data (akin to _wxGetBitmapFromMemory)
+    
     QImage loadImageFromData(const QByteArray& data, const char* format = "PNG");
+    bool loadGameSpriteData(QSharedPointer<GameSprite> gameSprite, const QByteArray& sprite_sheet_data );
 
-    // Manages sprite sheets or individual sprite files
-    // This is a high-level function that might call internal helpers
-    // to populate GameSprite objects with their QImage parts.
-    bool loadGameSpriteData(QSharedPointer<GameSprite> gameSprite, const QByteArray& sprite_sheet_data /* or paths */);
-
-
-    // Getters for paths (if still relevant)
-    // QString getMetadataFileName() const;
-    // QString getSpritesFileName() const;
-
-    // Client version handling
     void setClientVersion(const ClientVersion& version);
     const ClientVersion* getClientVersion() const;
 
-
 private:
-    // Caches for different types of sprites
-    // Using QSharedPointer for automatic memory management of sprites
-    QMap<int, QSharedPointer<Sprite>> m_sprite_cache; // Generic sprites, could include editor sprites
+    QMap<int, QSharedPointer<Sprite>> m_sprite_cache; 
     QMap<int, QSharedPointer<GameSprite>> m_item_sprite_cache;
     QMap<int, QSharedPointer<GameSprite>> m_creature_sprite_cache;
-    // QMap<int, QSharedPointer<EditorSprite>> m_editor_sprite_cache; // Or merge with m_sprite_cache
-
-    // Store sprite metadata if not directly in GameSprite objects
-    // (e.g. raw data pointers if not immediately converted to QImages)
-
-    ClientVersion m_client_version; // Current client version for asset loading logic
-
-    // Paths for sprite data - might be set during loadSpriteAssets
+    
+    ClientVersion m_client_version; 
     QString m_metadata_file_path;
     QString m_sprites_file_path;
-
-    // Internal counters and flags from wxwidgets version
     uint16_t m_item_count = 0;
     uint16_t m_creature_count = 0;
-    // bool m_otfi_found = false;
-    // bool m_is_extended_format = false; // e.g. for .spr files
-    // bool m_has_transparency_in_spr = false; // for .spr files
-
-    // Helper methods for parsing .dat and .spr files would go here
-    // bool parseDatEntry(...);
-    // bool parseSprEntry(...);
 };
 
 #endif // GRAPHICMANAGER_H

--- a/Project_QT/src/Sprite.cpp
+++ b/Project_QT/src/Sprite.cpp
@@ -2,36 +2,18 @@
 #include <QBuffer>
 #include <QColor>
 #include <QPainter>
+#include <QPixmap> // For getPixmap() implementation
 
 Sprite::Sprite() {
-    // Initialize with a null image or a default small transparent image
     m_image = QImage(1, 1, QImage::Format_ARGB32_Premultiplied);
     m_image.fill(Qt::transparent);
 }
 
 Sprite::~Sprite() {
-    // QImage is implicitly shared, so no explicit deletion of m_image data is needed here
-    // unless it was allocated with 'new'.
 }
-
-// Basic draw implementation, can be overridden by subclasses
-// void Sprite::draw(QPainter* painter, int x, int y, int width, int height) { // Already declared pure virtual
-//     if (!painter || m_image.isNull()) {
-//         return;
-//     }
-//     if (width == -1) {
-//         width = m_image.width();
-//     }
-//     if (height == -1) {
-//         height = m_image.height();
-//     }
-//     painter->drawImage(QRect(x, y, width, height), m_image);
-// }
 
 bool Sprite::load(const QString& path) {
     if (m_image.load(path)) {
-        // Optionally convert to a preferred format after loading
-        // m_image = m_image.convertToFormat(QImage::Format_ARGB32_Premultiplied);
         return true;
     }
     return false;
@@ -39,8 +21,6 @@ bool Sprite::load(const QString& path) {
 
 bool Sprite::loadFromData(const QByteArray& data, const char* format) {
     if (m_image.loadFromData(data, format)) {
-        // Optionally convert to a preferred format after loading
-        // m_image = m_image.convertToFormat(QImage::Format_ARGB32_Premultiplied);
         return true;
     }
     return false;
@@ -53,38 +33,40 @@ QImage Sprite::getImage() const {
 void Sprite::setImage(const QImage& image) {
     m_image = image;
     if (m_image.isNull()){
-        // Ensure m_image is never truly null to avoid crashes, assign a default small image
         m_image = QImage(1, 1, QImage::Format_ARGB32_Premultiplied);
         m_image.fill(Qt::transparent);
     }
 }
 
+QPixmap Sprite::getPixmap() const {
+    if (m_image.isNull()) {
+        return QPixmap(); 
+    }
+    return QPixmap::fromImage(m_image);
+}
+
 QImage Sprite::scale(const QSize& size, Qt::AspectRatioMode aspectRatioMode, Qt::TransformationMode transformMode) {
     if (m_image.isNull()) {
-        return QImage(); // Return a null QImage if there's no image to scale
+        return QImage(); 
     }
     return m_image.scaled(size, aspectRatioMode, transformMode);
 }
 
 void Sprite::setTransparency(int alpha) {
-    if (m_image.isNull()) { // Check if m_image is null before using it
-        m_image = QImage(1,1,QImage::Format_ARGB32_Premultiplied); // Ensure it's valid
+    if (m_image.isNull()) { 
+        m_image = QImage(1,1,QImage::Format_ARGB32_Premultiplied); 
         m_image.fill(Qt::transparent);
     }
     
     if (!m_image.hasAlphaChannel()) {
-        // If no alpha channel, convert it to a format that has one.
-        // Format_ARGB32_Premultiplied is a common choice for images with transparency.
         m_image = m_image.convertToFormat(QImage::Format_ARGB32_Premultiplied);
     }
 
-    // Create a new image with the desired alpha
     QImage tempImage = QImage(m_image.size(), QImage::Format_ARGB32_Premultiplied);
-    tempImage.fill(Qt::transparent); // Start with a transparent image
+    tempImage.fill(Qt::transparent); 
 
     QPainter painter(&tempImage);
     painter.setCompositionMode(QPainter::CompositionMode_Source);
-    // Ensure alpha is within valid range for QPainter::setOpacity (0.0 to 1.0)
     double opacity = qBound(0.0, static_cast<double>(alpha) / 255.0, 1.0);
     painter.setOpacity(opacity);
     painter.drawImage(0, 0, m_image);
@@ -93,23 +75,16 @@ void Sprite::setTransparency(int alpha) {
     m_image = tempImage;
 }
 
-// This is a simplified version. A more accurate wxImage::SetMaskColour equivalent
-// would involve iterating pixels and setting those matching 'color' to transparent.
 void Sprite::setMaskColor(const QColor& color, bool enable) {
     if (m_image.isNull()) {
         return;
     }
 
     if (enable) {
-        // Convert to a format with an alpha channel if it doesn't have one
         if (!m_image.hasAlphaChannel()) {
             m_image = m_image.convertToFormat(QImage::Format_ARGB32_Premultiplied);
         }
-        // Create a QBitmap mask
-        // For QImage, createMaskFromColor is not a direct method.
-        // We need to iterate or use QPixmap intermediate for advanced masking.
-        // A simple approach for QImage:
-        QImage new_image = m_image.convertToFormat(QImage::Format_ARGB32_Premultiplied); // Ensure alpha channel
+        QImage new_image = m_image.convertToFormat(QImage::Format_ARGB32_Premultiplied); 
         for (int y = 0; y < new_image.height(); ++y) {
             for (int x = 0; x < new_image.width(); ++x) {
                 if (QColor(new_image.pixel(x, y)) == color) {
@@ -120,11 +95,8 @@ void Sprite::setMaskColor(const QColor& color, bool enable) {
         m_image = new_image;
 
     } else {
-        // Disabling mask: This is complex. If the original pixels were preserved, they could be restored.
-        // For now, this makes the image opaque again by removing alpha channel or setting alpha to full.
-        // This simplified version does not restore original pixel colors if they were overwritten by transparency.
         if (m_image.hasAlphaChannel()) {
-             m_image = m_image.convertToFormat(QImage::Format_RGB32); // Or some other opaque format
+             m_image = m_image.convertToFormat(QImage::Format_RGB32); 
         }
     }
 }

--- a/Project_QT/src/Sprite.h
+++ b/Project_QT/src/Sprite.h
@@ -2,11 +2,11 @@
 #define SPRITE_H
 
 #include <QImage>
-#include <QPainter> // For QPaintDevice, which QImage is
+#include <QPixmap> // Added for QPixmap
+#include <QPainter> 
 #include <QSize>
-#include <QColor> // Added for QColor
+#include <QColor> 
 
-// Forward declaration
 class QPaintDevice;
 
 class Sprite {
@@ -15,17 +15,17 @@ public:
     virtual ~Sprite();
 
     virtual void draw(QPainter* painter, int x, int y, int width = -1, int height = -1) = 0;
-    virtual bool load(const QString& path); // Generic load, might be from file or data
+    virtual bool load(const QString& path); 
     virtual bool loadFromData(const QByteArray& data, const char* format = nullptr);
 
     virtual QImage getImage() const;
     virtual void setImage(const QImage& image);
 
-    virtual QImage scale(const QSize& size, Qt::AspectRatioMode aspectRatioMode = Qt::IgnoreAspectRatio, Qt::TransformationMode transformMode = Qt::SmoothTransformation);
-    virtual void setTransparency(int alpha); // Simple alpha channel setting
-    
-    virtual void setMaskColor(const QColor& color, bool enable = true);
+    virtual QPixmap getPixmap() const; 
 
+    virtual QImage scale(const QSize& size, Qt::AspectRatioMode aspectRatioMode = Qt::IgnoreAspectRatio, Qt::TransformationMode transformMode = Qt::SmoothTransformation);
+    virtual void setTransparency(int alpha); 
+    virtual void setMaskColor(const QColor& color, bool enable = true);
 
 protected:
     QImage m_image;


### PR DESCRIPTION
- Added getPixmap() to Sprite class.
- GraphicManager now provides getPixmap methods for sprites.
- CreatureSpriteManager now caches and returns QPixmap objects.