### PR TITLE
feat(Task4): Migrate ZoneBrushPanel and BrushSizePanel to Qt

### DIFF
--- a/Project_QT/src/ui/BrushSizePanel.cpp
+++ b/Project_QT/src/ui/BrushSizePanel.cpp
@@ -1,0 +1,145 @@
+#include "BrushSizePanel.h"
+#include <QPushButton>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QSpacerItem>
+#include <QSizePolicy>
+#include <QButtonGroup>
+#include <QDebug> // For placeholder event handlers
+
+const int NUM_SIZE_BUTTONS = 7;
+
+BrushSizePanel::BrushSizePanel(QWidget *parent) : 
+    QWidget(parent), 
+    m_largeIcons(true), // Default to large icons layout
+    m_row1Widget(nullptr),
+    m_row2Widget(nullptr) 
+{
+    setupUi();
+    updateLayout(); // Initial layout construction
+
+    // Connections
+    // Using QButtonGroup's idClicked signal
+    connect(m_shapeButtonGroup, QOverload<int>::of(&QButtonGroup::idClicked), this, &BrushSizePanel::onShapeButtonClicked);
+    connect(m_sizeButtonGroup, QOverload<int>::of(&QButtonGroup::idClicked), this, &BrushSizePanel::onSizeButtonClicked);
+}
+
+BrushSizePanel::~BrushSizePanel() {
+    // Child widgets and layouts managed by Qt's ownership
+}
+
+void BrushSizePanel::setupUi() {
+    m_mainLayout = new QVBoxLayout(this); // Set main layout on this widget
+
+    m_shapeButtonGroup = new QButtonGroup(this);
+    m_shapeButtonGroup->setExclusive(true); // Ensure only one shape is selected
+    m_sizeButtonGroup = new QButtonGroup(this);
+    m_sizeButtonGroup->setExclusive(true); // Only one size can be active
+
+    m_brushshapeSquareButton = new QPushButton(tr("Sq")); 
+    m_brushshapeSquareButton->setCheckable(true);
+    m_brushshapeSquareButton->setToolTip(tr("Square brush")); 
+    m_shapeButtonGroup->addButton(m_brushshapeSquareButton, 0); 
+
+    m_brushshapeCircleButton = new QPushButton(tr("Ci")); 
+    m_brushshapeCircleButton->setCheckable(true);
+    m_brushshapeCircleButton->setToolTip(tr("Circle brush")); 
+    m_shapeButtonGroup->addButton(m_brushshapeCircleButton, 1); 
+    
+    m_sizeButtons.reserve(NUM_SIZE_BUTTONS);
+    const char* sizeTooltips[NUM_SIZE_BUTTONS] = {
+        "Brush size 1x1", "Brush size 3x3", "Brush size 5x5",
+        "Brush size 7x7", "Brush size 9x9", "Brush size 15x15",
+        "Brush size 19x19"
+    };
+    for (int i = 0; i < NUM_SIZE_BUTTONS; ++i) {
+        QPushButton* button = new QPushButton(QString::number(i + 1)); 
+        button->setCheckable(true);
+        button->setToolTip(tr(sizeTooltips[i]));
+        m_sizeButtons.append(button);
+        m_sizeButtonGroup->addButton(button, i); 
+    }
+
+    if(m_brushshapeSquareButton) m_brushshapeSquareButton->setChecked(true);
+    if (!m_sizeButtons.isEmpty()) {
+        m_sizeButtons[0]->setChecked(true);
+    }
+}
+
+void BrushSizePanel::setLargeIcons(bool largeIcons) {
+    if (m_largeIcons == largeIcons) {
+        return;
+    }
+    m_largeIcons = largeIcons;
+    updateLayout();
+}
+
+void BrushSizePanel::updateLayout() {
+    if (m_row1Widget) {
+        m_mainLayout->removeWidget(m_row1Widget);
+        delete m_row1Widget;
+        m_row1Widget = nullptr;
+    }
+    if (m_row2Widget) {
+        m_mainLayout->removeWidget(m_row2Widget);
+        delete m_row2Widget;
+        m_row2Widget = nullptr;
+    }
+    
+    QLayoutItem* item;
+    while ((item = m_mainLayout->takeAt(0)) != nullptr) {
+        if (item->spacerItem()) {
+            delete item->spacerItem();
+        }
+        delete item; 
+    }
+
+    if (m_largeIcons) {
+        m_row1Widget = new QWidget(this);
+        QHBoxLayout* row1Layout = new QHBoxLayout(m_row1Widget);
+        row1Layout->setContentsMargins(0,0,0,0); 
+        row1Layout->addWidget(m_brushshapeSquareButton);
+        row1Layout->addWidget(m_brushshapeCircleButton);
+        row1Layout->addSpacerItem(new QSpacerItem(36, 0, QSizePolicy::Fixed, QSizePolicy::Minimum)); // Fixed spacer
+        if (NUM_SIZE_BUTTONS > 0) row1Layout->addWidget(m_sizeButtons[0]);
+        if (NUM_SIZE_BUTTONS > 1) row1Layout->addWidget(m_sizeButtons[1]);
+        m_mainLayout->addWidget(m_row1Widget);
+
+        if (NUM_SIZE_BUTTONS > 2) {
+            m_row2Widget = new QWidget(this);
+            QHBoxLayout* row2Layout = new QHBoxLayout(m_row2Widget);
+            row2Layout->setContentsMargins(0,0,0,0);
+            for (int i = 2; i < NUM_SIZE_BUTTONS; ++i) {
+                row2Layout->addWidget(m_sizeButtons[i]);
+            }
+            row2Layout->addStretch(1); 
+            m_mainLayout->addWidget(m_row2Widget);
+        }
+    } else {
+        m_row1Widget = new QWidget(this);
+        QHBoxLayout* rowLayout = new QHBoxLayout(m_row1Widget);
+        rowLayout->setContentsMargins(0,0,0,0);
+        rowLayout->addWidget(m_brushshapeSquareButton);
+        rowLayout->addWidget(m_brushshapeCircleButton);
+        rowLayout->addSpacerItem(new QSpacerItem(18, 0, QSizePolicy::Fixed, QSizePolicy::Minimum)); // Fixed spacer
+        for (int i = 0; i < NUM_SIZE_BUTTONS; ++i) {
+            rowLayout->addWidget(m_sizeButtons[i]);
+        }
+        rowLayout->addStretch(1); 
+        m_mainLayout->addWidget(m_row1Widget);
+    }
+    m_mainLayout->addStretch(1); 
+}
+
+void BrushSizePanel::onShapeButtonClicked(int id) {
+    qDebug() << "BrushSizePanel: Shape button clicked, id:" << id;
+    // QButtonGroup with setExclusive(true) handles unchecking.
+    // If it was not exclusive, you'd do:
+    // if (id == 0 && m_brushshapeCircleButton) m_brushshapeCircleButton->setChecked(false);
+    // if (id == 1 && m_brushshapeSquareButton) m_brushshapeSquareButton->setChecked(false);
+}
+
+void BrushSizePanel::onSizeButtonClicked(int id) {
+    qDebug() << "BrushSizePanel: Size button clicked, id (0-6):" << id;
+    // QButtonGroup handles unchecking others.
+}

--- a/Project_QT/src/ui/BrushSizePanel.h
+++ b/Project_QT/src/ui/BrushSizePanel.h
@@ -1,0 +1,45 @@
+#ifndef BRUSHSIZEPANEL_H
+#define BRUSHSIZEPANEL_H
+
+#include <QWidget>
+#include <QVector> // For storing buttons
+
+// Forward declarations
+class QPushButton;
+class QVBoxLayout;
+class QButtonGroup; // To manage size buttons
+
+class BrushSizePanel : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit BrushSizePanel(QWidget *parent = nullptr);
+    ~BrushSizePanel() override;
+
+    void setLargeIcons(bool largeIcons);
+
+private slots:
+    void onShapeButtonClicked(int id);
+    void onSizeButtonClicked(int id);
+
+private:
+    void setupUi();
+    void updateLayout(); // Helper to change layout based on m_largeIcons
+
+    bool m_largeIcons;
+
+    QPushButton* m_brushshapeSquareButton;
+    QPushButton* m_brushshapeCircleButton;
+    
+    QVector<QPushButton*> m_sizeButtons; // To hold the 7 size buttons
+
+    QButtonGroup* m_shapeButtonGroup;
+    QButtonGroup* m_sizeButtonGroup;
+
+    QVBoxLayout* m_mainLayout;
+    // Keep pointers to the row layouts to remove/add them
+    QWidget* m_row1Widget; // Using QWidget as a container for QHBoxLayout
+    QWidget* m_row2Widget; // Using QWidget as a container for QHBoxLayout
+};
+
+#endif // BRUSHSIZEPANEL_H

--- a/Project_QT/src/ui/ZoneBrushPanel.cpp
+++ b/Project_QT/src/ui/ZoneBrushPanel.cpp
@@ -1,0 +1,61 @@
+#include "ZoneBrushPanel.h"
+#include <QPushButton>
+#include <QSpinBox>
+#include <QHBoxLayout>
+#include <QDebug> // For placeholder event handlers
+
+ZoneBrushPanel::ZoneBrushPanel(QWidget *parent) : QWidget(parent) {
+    setupUi();
+
+    // Connections (matching event table from wxwidgets analysis)
+    connect(m_zoneButton, &QPushButton::toggled, this, &ZoneBrushPanel::onZoneButtonToggled);
+    // QSpinBox has valueChanged(int) for programmatic changes and editingFinished() for when user is done.
+    // wxEVT_COMMAND_SPINCTRL_UPDATED is when value changes by arrows.
+    // wxEVT_COMMAND_TEXT_UPDATED is when text changes (could be intermediate).
+    // Using valueChanged(int) for simplicity to catch all value changes.
+    connect(m_zoneIdSpin, QOverload<int>::of(&QSpinBox::valueChanged), this, &ZoneBrushPanel::onZoneIdChanged);
+}
+
+ZoneBrushPanel::~ZoneBrushPanel() {
+    // Qt's parent-child ownership will handle deletion of child widgets and layout.
+}
+
+void ZoneBrushPanel::setupUi() {
+    m_zoneButton = new QPushButton(tr("Zone Brush")); // Placeholder text
+    m_zoneButton->setCheckable(true); // Emulates wxToggleButton
+    m_zoneButton->setToolTip(tr("Zone Brush")); // Tooltip from wxwidgets
+
+    m_zoneIdSpin = new QSpinBox();
+    m_zoneIdSpin->setRange(0, 65535); // Typical range for IDs
+    m_zoneIdSpin->setValue(1); // Default value like in wxwidgets
+    m_zoneIdSpin->setToolTip(tr("Zone ID")); // Tooltip
+
+    QHBoxLayout* layout = new QHBoxLayout(this); // 'this' sets the layout on ZoneBrushPanel
+    layout->addWidget(m_zoneButton);
+    layout->addWidget(m_zoneIdSpin);
+    
+    // Replicating wxSizerFlags(1).Center() for zoneIdSpin:
+    // The stretch factor of 1 makes it take available horizontal space relative to other widgets.
+    // Alignment within its allocated space is usually handled by widget's internal properties
+    // or can be influenced by QLayout::setAlignment for specific widgets.
+    // For a QSpinBox, vertical centering is typical within a QHBoxLayout.
+    // Add stretch to zoneIdSpin to make it expand
+    layout->setStretchFactor(m_zoneIdSpin, 1); 
+
+    // setLayout(layout); // Already done by QHBoxLayout(this)
+}
+
+void ZoneBrushPanel::onZoneButtonToggled(bool checked) {
+    // Placeholder for original event handler logic
+    qDebug() << "ZoneBrushPanel: zoneButton toggled:" << checked;
+    // Original logic (example):
+    // g_gui.ActivatePalette(GetParentPalette()); // Need to adapt how parent palette is accessed
+    // g_gui.SelectBrush(g_gui.zone_brush); // Need to adapt global brush access
+}
+
+void ZoneBrushPanel::onZoneIdChanged(int value) {
+    // Placeholder for original event handler logic
+    qDebug() << "ZoneBrushPanel: zoneIdSpin changed:" << value;
+    // Original logic (example):
+    // g_gui.zone_brush->setZoneId(value); // Need to adapt global brush access
+}

--- a/Project_QT/src/ui/ZoneBrushPanel.h
+++ b/Project_QT/src/ui/ZoneBrushPanel.h
@@ -1,0 +1,29 @@
+#ifndef ZONEBRUSHPANEL_H
+#define ZONEBRUSHPANEL_H
+
+#include <QWidget>
+
+// Forward declarations
+class QPushButton;
+class QSpinBox;
+class QHBoxLayout;
+
+class ZoneBrushPanel : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ZoneBrushPanel(QWidget *parent = nullptr);
+    ~ZoneBrushPanel() override;
+
+private slots:
+    void onZoneButtonToggled(bool checked);
+    void onZoneIdChanged(int value);
+
+private:
+    void setupUi();
+
+    QPushButton* m_zoneButton;
+    QSpinBox* m_zoneIdSpin;
+};
+
+#endif // ZONEBRUSHPANEL_H


### PR DESCRIPTION
- I created Qt QWidget subclasses for ZoneBrushPanel and BrushSizePanel.
- I replicated wxSizer layouts using QHBoxLayout and QVBoxLayout.
- I used QPushButton as placeholders for custom button types (BrushButton, DCButton).
- I added basic signal/slot connections for events previously handled in wxwidgets.